### PR TITLE
Remove text change observer

### DIFF
--- a/BZGFormField/BZGFormField.m
+++ b/BZGFormField/BZGFormField.m
@@ -113,6 +113,10 @@ alpha:1.0]
 
 }
 
+- (void) dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 #pragma mark - Drawing
 
 - (void)updateLeftIndicatorState:(BZGLeftIndicatorState)leftIndicatorState


### PR DESCRIPTION
Thanks for a great component!

This pull fixes a crash caused by the text field not being removed as an observer of `UITextFieldTextDidChangeNotification`.
