### PR TITLE
Fixed vertical alignment for iOS 6.x compatibility

### DIFF
--- a/BZGFormField/BZGFormField.m
+++ b/BZGFormField/BZGFormField.m
@@ -100,6 +100,7 @@ static NSString * const kValidationAnimationKey = @"validationAnimationKey";
     self.textField.delegate = self;
     self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
     self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    self.textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
     self.textField.text = @" ";
     [self addSubview:self.textField];
 


### PR DESCRIPTION
In iOS 6 the text field is aligning to top be default (rather than center). Added explicit vertical alignment setting  to UIControlContentVerticalAlignmentCenter for IOS < 7 compatibility.
