### PR TITLE
Left Indicator width not updating on setter

### DIFF
--- a/BZGFormField/BZGFormField.m
+++ b/BZGFormField/BZGFormField.m
@@ -33,6 +33,24 @@ static NSString * const kValidationAnimationKey = @"validationAnimationKey";
 
 #pragma mark - Public
 
+- (void)setLeftIndicatorInactiveWidth:(CGFloat)leftIndicatorInactiveWidth
+{
+    _leftIndicatorInactiveWidth = leftIndicatorInactiveWidth;
+    if (_currentLeftIndicatorState == BZGLeftIndicatorStateInactive) {
+        _currentLeftIndicatorAspectRatio = leftIndicatorInactiveWidth;
+        [self setNeedsLayout];
+    }
+}
+
+- (void)setLeftIndicatorActiveWidth:(CGFloat)leftIndicatorActiveWidth
+{
+    _leftIndicatorActiveWidth = leftIndicatorActiveWidth;
+    if (_currentLeftIndicatorState == BZGLeftIndicatorStateActive) {
+        _currentLeftIndicatorAspectRatio = leftIndicatorActiveWidth;
+        [self setNeedsLayout];
+    }
+}
+
 - (BZGLeftIndicatorState)leftIndicatorState
 {
     return _currentLeftIndicatorState;
@@ -42,7 +60,6 @@ static NSString * const kValidationAnimationKey = @"validationAnimationKey";
 {
     return _currentFormFieldState;
 }
-
 
 - (void)setTextValidationBlock:(BZGTextValidationBlock)block
 {


### PR DESCRIPTION
When the left indicator width is set, it does not redraw the view with
the new width. Even if the view is forced to redraw (e.g. change the
frame or call setNeedsLayout), layoutSubviews will still use the old
cached value not the new value. The only way to force the new left
indicator width to take effect is by calling setText or changing the
text in the text field. I have created custom setters that will
correctly redraw the view when the indicator width is changed.
